### PR TITLE
Removing unnecessary import

### DIFF
--- a/pytheas-core/src/main/java/com/netflix/explorers/sse/EventChannel.java
+++ b/pytheas-core/src/main/java/com/netflix/explorers/sse/EventChannel.java
@@ -26,7 +26,6 @@ import com.netflix.explorers.resources.EmbeddedContentResource;
 import org.cliffc.high_scale_lib.NonBlockingHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.util.LocaleServiceProviderPool;
 
 public class EventChannel implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(EventChannel.class);


### PR DESCRIPTION
This particular import is not used anywhere.  Further, it's causing problems when pytheas is run with Java 8 since this (internal) API has apparently been removed.
