### PR TITLE
pytheas-core shouldn't depend on slf4j binding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,8 @@ subprojects {
         compile 'com.sun.jersey:jersey-json:1.11'
         compile 'com.sun.jersey:jersey-servlet:1.11'
 
-        compile 'org.slf4j:slf4j-api:1.7.0'
+        compile 'org.slf4j:slf4j-api:1.7.7'
         compile 'com.netflix.karyon:karyon-core:1.0.22'
-        runtime 'org.slf4j:slf4j-simple:1.7.0'
         testCompile 'junit:junit:4.10'
         testCompile 'org.mockito:mockito-core:1.8.5'
     }
@@ -44,7 +43,7 @@ project(':pytheas-core') {
 
     dependencies {
         compile 'commons-configuration:commons-configuration:1.8'
-        compile 'com.google.guava:guava:14.0'
+        compile 'com.google.guava:guava:14.0.1'
         compile 'com.google.inject.extensions:guice-servlet:3.0'
         compile 'org.codehaus.jettison:jettison:1.1'
         compile 'javax.servlet:servlet-api:2.5'
@@ -73,6 +72,7 @@ project(':pytheas-helloworld') {
     dependencies {
         compile project(':pytheas-core')
         compile 'com.netflix.karyon:karyon-extensions:1.0.22'
+        runtime 'org.slf4j:slf4j-simple:1.7.7'
         testCompile 'org.eclipse.jetty:jetty-server:7.6.7.v20120910'
         testCompile 'org.eclipse.jetty:jetty-servlet:7.6.7.v20120910'
     }


### PR DESCRIPTION
Currently pytheas-core has a direct runtime dependency on slf4j-simple
which often results in multiple slf4j bindings in the classpath
of the actual app. The pytheas-core lib should only depend on
the api.

This change also bumps the guava and slf4j versions to match the
common versions used internally right now.
