### PR TITLE
update to karyon 1.0.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
         compile 'com.sun.jersey:jersey-servlet:1.11'
 
         compile 'org.slf4j:slf4j-api:1.7.7'
-        compile 'com.netflix.karyon:karyon-core:1.0.22'
+        compile 'com.netflix.karyon:karyon-core:1.0.27'
         testCompile 'junit:junit:4.10'
         testCompile 'org.mockito:mockito-core:1.8.5'
     }
@@ -71,7 +71,7 @@ project(':pytheas-helloworld') {
 
     dependencies {
         compile project(':pytheas-core')
-        compile 'com.netflix.karyon:karyon-extensions:1.0.22'
+        compile 'com.netflix.karyon:karyon-extensions:1.0.27'
         runtime 'org.slf4j:slf4j-simple:1.7.7'
         testCompile 'org.eclipse.jetty:jetty-server:7.6.7.v20120910'
         testCompile 'org.eclipse.jetty:jetty-servlet:7.6.7.v20120910'


### PR DESCRIPTION
The 1.0.22 version of karyon currently being
used has a range specified for the governator
dependency. This is causing an incompatible
version of governator to be pulled in:
https://github.com/Netflix/karyon/issues/133

The 1.0.27 depends on governator 1.2.12
explicitly.
